### PR TITLE
Update WebService.php

### DIFF
--- a/ifthenpay/classes/Request/WebService.php
+++ b/ifthenpay/classes/Request/WebService.php
@@ -62,18 +62,20 @@ class WebService
         return json_decode(json_encode(json_decode((string) $this->response->getBody())), true);
     }
 
-    public function postRequest($url, $data, $json = false)
-    {
-        try {
-            $this->response = $this->client->post(
-                $url,
-                $json ? ['json' => $data] : ['form_params' => $data]
-            );
-            return $this;
-        } catch (\Throwable $th) {
-            throw $th;
-        }
+public function postRequest($url, $data, $jsonContentType = false)
+{
+    try {
+        $this->response = $this->client->post(
+            $url,
+            $jsonContentType ? ['json' => $data] :
+            ['form_params' => $data]
+        );
+        return $this;
+    } catch (\Throwable $th) {
+        throw $th;
     }
+}
+
 
     public function getRequest($url, $data = [])
     {


### PR DESCRIPTION
This line:

['body' => $data]
is passing an array to the body option — which Guzzle does not support for application/x-www-form-urlencoded. That's exactly what the error is about.

Why this works:
'json' => $data — tells Guzzle to encode the body as JSON and set Content-Type: application/json

'form_params' => $data — tells Guzzle to encode the body as URL-encoded form data (key1=value1&key2=value2...), and set Content-Type: application/x-www-form-urlencoded